### PR TITLE
Add empty otl dirs

### DIFF
--- a/houdini18.0/otls/README.md
+++ b/houdini18.0/otls/README.md
@@ -1,0 +1,4 @@
+# OTLS
+
+HDAs/OTLs go here. This README is placeholder since git won't upload empty
+directories. Feel free to delete it.

--- a/houdini18.5/otls/README.md
+++ b/houdini18.5/otls/README.md
@@ -1,0 +1,4 @@
+# OTLS
+
+HDAs/OTLs go here. This README is placeholder since git won't upload empty
+directories. Feel free to delete it.

--- a/houdini19.0/otls/README.md
+++ b/houdini19.0/otls/README.md
@@ -1,0 +1,4 @@
+# OTLS
+
+HDAs/OTLs go here. This README is placeholder since git won't upload empty
+directories. Feel free to delete it.

--- a/initialize.py
+++ b/initialize.py
@@ -199,10 +199,17 @@ def main():
         # Rename the file if necessary
         rename(fname, package_name)
 
-    # Rename any dirs
+    # Rename any dirs and cleanup boilerplate READMEs
     for dname in set(all_dirs):
+        if fnmatch.fnmatch(dname, "*houdini*/otls"):
+            try:
+                print("Removing placeholder at {0}/README.md".format(dname))
+                os.remove(os.path.join(dname, "README.md"))
+            except OSError:
+                print("Unable to remove {0}/README.md".format(dname))
+                pass
         rename(dname, package_name)
-    print("Done.")
+    print("\033[0;37;42m" + "Done." + "\033[0m")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Git won't upload empty dirs, which is why the `otls/` / `hda/` dirs never made it in. Added a basic `README.md` to each one that can be deleted.